### PR TITLE
chore: bumps fmp to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <camel.version>2.21.0</camel.version>
 
         <!-- versions of Maven plugins -->
-        <fmp.version>3.5.33</fmp.version>
+        <fmp.version>3.5.40</fmp.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
With the new version of fabric8-maven-plugin we have fixed quite a bit of issues visible in OSIO so it would be great if we can bump it for this booster.