### PR TITLE
Bump FMP version to 4.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <camel.version>2.21.2</camel.version>
 
         <!-- versions of Maven plugins -->
-        <fmp.version>3.5.40</fmp.version>
+        <fmp.version>4.0.0</fmp.version>
 
         <!-- version of Arquillian -->
         <arquillian.cube.version>1.17.1</arquillian.cube.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <camel.version>2.21.2</camel.version>
 
         <!-- versions of Maven plugins -->
-        <fmp.version>4.0.0</fmp.version>
+        <fmp.version>4.3.1</fmp.version>
 
         <!-- version of Arquillian -->
         <arquillian.cube.version>1.17.1</arquillian.cube.version>


### PR DESCRIPTION
Signed-off-by: svor <vsvydenk@redhat.com>

If try to deploy this sample on OpenShift 4 by `mvn clean fabric8:deploy -Popenshift`, I see  an error:
```log
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 13.275 s
[INFO] Finished at: 2019-11-08T14:24:29Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal io.fabric8:fabric8-maven-plugin:3.5.40:build (default) on project fuse-rest-http-booster: Execution default of goal io.fabric8:fabric8-maven-plugin:3.5.40:build failed: No <dockerHost> given, no DOCKER_HOST environment variable, no read/writable '/var/run/docker.sock' or '//./pipe/docker_engine' and no external provider like Docker machine configured -> [Help 1]
[ERROR]
```
This PR bumps FMP version to 4.3.1 make it possible to deploy this sample on OpenShift 4. It also works for OpenShift 3.