### PR TITLE
provide devfile v2 initial configuration eclipse/che#50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ hs_err_pid*
 target/
 .idea/
 *.iml
-.vscode/
 .classpath
 .project
 .settings/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846
+  // for the documentation about the extensions.json format
+  "recommendations": [
+    "redhat.java",
+    "redhat.vscode-xml",
+    "redhat.vscode-apache-camel"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "java",
+            "name": "Debug (Attach) - Remote",
+            "request": "attach",
+            "hostName": "localhost",
+            "port": 5005
+        }
+    ]
+}

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,0 +1,52 @@
+schemaVersion: 2.1.0
+metadata:
+  name: apache-camel-springboot
+attributes:
+  che-theia.eclipse.org/sidecar-policy: USE_DEV_CONTAINER
+components:
+  - name: tools
+    container:
+      image: quay.io/devfile/universal-developer-image:ubi8-d433ed6
+      endpoints:
+        - exposure: none
+          name: debug
+          protocol: tcp
+          targetPort: 5005
+        - exposure: public
+          name: 8080-tcp
+          protocol: http
+          targetPort: 8080
+      volumeMounts:
+        - name: m2
+          path: /home/user/.m2
+      memoryLimit: 3Gi
+  - name: m2
+    volume:
+      size: 1G
+commands:
+  - id: build
+    exec:
+      component: tools
+      workingDir: ${PROJECTS_ROOT}/fuse-rest-http-booster
+      commandLine: mvn clean install
+      group:
+        kind: build
+        isDefault: true
+  - id: run
+    exec:
+      component: tools
+      workingDir: ${PROJECTS_ROOT}/fuse-rest-http-booster
+      commandLine: >-
+        java -jar target/*.jar
+      group:
+        kind: run
+        isDefault: true
+  - id: run-debug
+    exec:
+      component: tools
+      workingDir: ${PROJECTS_ROOT}/fuse-rest-http-booster
+      commandLine: >-
+        java -jar -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005 target/*.jar
+      group:
+        kind: run
+        isDefault: true


### PR DESCRIPTION
adapted from:
- https://github.com/che-samples/java-spring-petclinic/tree/devfilev2
- https://github.com/eclipse-che/che-devfile-registry/blob/main/devfiles/apache-camel-springboot/devfile.yaml

sharing to show progress but wasn't able to test it so far as I failed to create a working CodeReady Workspaces with devworkspace enabled.
(tried chectl on minikube which is failign on `✖ Wait for Cert Manager→ ERR_TIMEOUT: Timeout set to pod ready timeout 600000`, tried with chectl on crc but websocket failed connection on workspace, tried to access on ibm cloud instance bt wasn't manage to have a working OpenShift)